### PR TITLE
Fix hasOwnProperty being undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ function listPropsFromObject(resource, prefix) {
     prefix = prefix || '';
 
     for (var i in resource) {
-        if (!resource.hasOwnProperty(i)) {
+        if (!Object.prototype.hasOwnProperty.call(resource, i)) {
             continue;
         }
 
@@ -177,7 +177,7 @@ function objectHas(resource, paths) {
 }
 
 var objectHasChildProp = function(object, property) {
-    return object && property && object.hasOwnProperty(property) && typeof object[property] !== 'undefined';
+    return object && property && Object.prototype.hasOwnProperty.call(object, property) && typeof object[property] !== 'undefined';
 };
 
 MonocleProps.prototype.set = function(fullPath, value) {
@@ -189,7 +189,7 @@ MonocleProps.prototype.set = function(fullPath, value) {
     parents.forEach(function(item) {
         switch (last.type) {
             case 'object':
-                if (item.hasOwnProperty(last.property)) {
+                if (Object.prototype.hasOwnProperty.call(item, last.property)) {
                     item[last.property] = value;
                 }
                 break;
@@ -203,7 +203,7 @@ MonocleProps.prototype.set = function(fullPath, value) {
                     debug('last path has a property', last);
                     // Set all of them
                     item.forEach(function(innerItem) {
-                        if (innerItem.hasOwnProperty(last.property)) {
+                        if (Object.prototype.hasOwnProperty.call(innerItem, last.property)) {
                             innerItem[last.property] = value;
                         }
                     });


### PR DESCRIPTION
Related to https://github.com/ifwe/monocle-api/pull/68

This property may be set to a value other than a function,
or the object prototype chain may not include Object.
This problem was encountered with newer node version(6) or upgraded dependencies.

Fixes `TypeError: object.hasOwnProperty is not a function`